### PR TITLE
add webpack support - implement DtsPackPlugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ If omitted, `'./tsconfig.json'` will be used.
 
 #### --entry, -e (string)
 
-Specifies the entry module name to expose exported entities. This is treated as a source name of the project, so the name must be the relative path name from the root source directory.
+Specifies the entry module name to expose exported entities. This is treated as a source file name of the project. If the path is relative, the path is treated as referring from the root source directory (from `baseUrl` or the project directory).
 If an extension is omitted, `.ts` will be appended.
 
 #### --moduleName, -m (string)
@@ -112,6 +112,51 @@ dts-pack -p ./tsconfig.json -e index.ts -m myModule -s module -x default -o ./di
 ```
 
 For creating namespace-style, change 'module' of the command line above to 'namespace'.
+
+## webpack plugin
+
+dts-pack can be used as a plugin for [webpack](https://webpack.js.org/). The `DtsPackPlugin` gathers all emitted files with an extension `.d.ts`, and emits one or two combined declaration file(s). Currently the plugin is tested only with the combination of webpack 3 and  [ts-loader](https://github.com/TypeStrong/ts-loader) (the plugin might be work on webpack 2, but not tested).
+
+### Usage
+
+```js
+var DtsPackPlugin = require('dts-pack').DtsPackPlugin;
+
+...
+// in the configuration
+{
+  ...
+  plugins: [
+    new DtsPackPlugin({
+      entry: 'index.ts',
+      moduleName: 'myModule'
+    })
+  ]
+}
+```
+
+... and **you need to set `declaration: true` option into the `tsconfig.json`** if `useProjectSources` is not `true`.
+
+### Options (the first parameter of plugin's constructor)
+
+All options passed to the constructor of `DtsPackPlugin` are the same name to the command-line parameters. In addition, if `entry` and `moduleName` are the same to the webpack configuration (`entry` value and the key name of `entry` object respectively), they can also be omitted. Other options below can be collected from webpack configuration if not specified:
+
+- `outDir`: collected from `output.path`
+- `rootName`: collected from `output.library`
+
+The additional options below can also be used for the plugin (all options are optional).
+
+#### compilerOptions (ts.CompilerOptions)
+
+Compiler options overwriting the options in the `tsconfig.json`. These options are only used for TypeScript compiler using in the plugin; some options (such as `declaration`, `removeComments`, `stripInternal`, etc.) are not effective.
+
+If the module resolution is not working properly because of the difference of settings between webpack configuration and `tsconfig.json`, please use `compilerOptions` to resolve problems.
+
+#### useProjectSources (boolean)
+
+Specifies `true` if you want to use real source files in the project instead of emitted declaration files. This may cause slower buildings because the source files will be compiled twice.
+
+Regardless of this option, the original emitted declaration files are removed from outputs.
 
 ## License
 

--- a/package.json
+++ b/package.json
@@ -8,7 +8,9 @@
   "homepage": "https://github.com/jet2jet/dts-pack",
   "keywords": [
     "typescript",
-    "declaration"
+    "declaration",
+    "webpack",
+    "plugin"
   ],
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
   },
   "devDependencies": {
     "@types/node": "6",
+    "@types/webpack": "2",
     "@types/yargs": "^10.0.1"
   }
 }

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -21,6 +21,8 @@ import makeChildModule from './packer/makeChildModule';
 import rebuildAST from './packer/rebuildAST';
 import resolveModule from './packer/resolveModule';
 
+import DtsPackPlugin from './plugin/DtsPackPlugin';
+
 ////////////////////////////////////////////////////////////////////////////////
 
 function convertDeclFileNameToSourceFileName(compilerOptions: ts.CompilerOptions, projectFile: string, declFile: string): string {
@@ -431,3 +433,5 @@ export function runWithFiles(
 export function run(messageWriter: (text: string) => void, options: Options): { files: { [fileName: string]: string }, warnings: string } {
 	return runWithFiles(messageWriter, options, {});
 }
+
+export { DtsPackPlugin };

--- a/src/main/plugin/DtsPackPlugin.ts
+++ b/src/main/plugin/DtsPackPlugin.ts
@@ -1,0 +1,161 @@
+import * as webpack from 'webpack';
+import * as path from 'path';
+
+import { runWithFiles } from '../index';
+
+import PluginOptions from './PluginOptions';
+
+type ComputedPluginOptions = PluginOptions & {
+	entry: string;
+	moduleName: string;
+	outDir: string;
+};
+
+interface WebpackAsset {
+	source(): string;
+	size(): number;
+}
+
+interface WebpackCompilation {
+	assets: { [fileName: string]: WebpackAsset };
+	[key: string]: any;
+}
+
+function computeOptions(options: PluginOptions, conf: webpack.Configuration): Promise<ComputedPluginOptions> {
+	return (() => { // returns (options.entry || conf.entry) with Promise
+		if (options.entry) {
+			return Promise.resolve(options.entry);
+		}
+		const e = conf.entry;
+		if (typeof (e) === 'function') {
+			// e: webpack.EntryFunc (since webpack 3)
+			const func = e as (() => (string | string[] | webpack.Entry | Promise<string | string[] | webpack.Entry>));
+			const p = func();
+			if (p instanceof Promise) {
+				return p;
+			}
+			return Promise.resolve(p);
+		}
+		return Promise.resolve(e);
+	})().then((v: string | string[] | webpack.Entry | undefined) => {
+		// compute entry and moduleName
+		let moduleName: string | undefined = options.moduleName;
+		if (!(v instanceof Array) && typeof (v) === 'object') {
+			// v: webpack.Entry
+			const keys = Object.keys(v);
+			if (keys.length === 1) {
+				// 'entry: { <moduleName>: <entry-point> }'
+				if (!moduleName) {
+					moduleName = keys[0];
+				}
+				v = v[keys[0]];
+			} else if (moduleName && v[moduleName]) {
+				v = v[moduleName];
+			} else {
+				throw new Error(`DtsPackPlugin: Multiple entry point is not allowed. Please specify 'entry' explicitly to the plugin option.`);
+			}
+		}
+		if (v instanceof Array) {
+			// use last one (webpack exports only the last item)
+			v = v.pop();
+		}
+		if (typeof (v) === 'string') {
+			// fail if moduleName is not specified or detected
+			if (!moduleName) {
+				throw new Error(`DtsPackPlugin: Cannot determine module name; please specify 'moduleName' to the plugin option.`);
+			}
+
+			// entry name may be relative path 
+			const entry = path.resolve(v);
+			// compute outDir from 'output.path' (if not specified, './' will be used)
+			const outDir = options.outDir || (conf.output && conf.output.path) || './';
+			// compute rootName from 'output.library' (if options.rootName is not specified)
+			let rootName = options.rootName;
+			if (!rootName && conf.output && conf.output.library) {
+				const l = conf.output.library as (string | string[]);
+				if (l instanceof Array) {
+					// (since webpack 3)
+					rootName = l.join('.');
+				} else {
+					rootName = l;
+				}
+			}
+			return Object.assign({},
+				options,
+				{
+					outDir: outDir,
+					entry: entry,
+					moduleName: moduleName,
+					rootName: rootName
+				}
+			);
+		}
+		throw new Error(`DtsPackPlugin: Cannot determine entry name; please specify 'entry' to the plugin option.`);
+	});
+}
+
+export default class DtsPackPlugin {
+	private options: PluginOptions;
+
+	constructor(options: PluginOptions = {}) {
+		this.options = options;
+	}
+
+	public apply(compiler: webpack.Compiler) {
+		compiler.plugin('emit', (compilation: WebpackCompilation, callback: (err?: any) => void) => {
+			computeOptions(this.options, compiler.options)
+				.then((opts) => {
+					const inputFiles: { [fileName: string]: string } = {};
+					let fileCount = 0;
+
+					Object.keys(compilation.assets).forEach((fileName) => {
+						if (/\.d\.ts$/i.test(fileName)) {
+							const asset = compilation.assets[fileName];
+							inputFiles[fileName] = asset.source();
+							++fileCount;
+							delete compilation.assets[fileName];
+						}
+					});
+
+					if (!opts.useProjectSources && fileCount === 0) {
+						// do nothing
+					} else {
+						const r = runWithFiles(
+							this.messageWriter.bind(this),
+							opts,
+							opts.useProjectSources ? {} : inputFiles,
+							false
+						);
+						if (r.warnings && console.warn) {
+							console.warn(r.warnings);
+						}
+						const newFiles = Object.keys(r.files);
+						newFiles.forEach((file) => {
+							const asset = ((src: string): WebpackAsset => {
+								return {
+									source: () => src,
+									size: () => src.length
+								};
+							})(r.files[file]);
+							compilation.assets[path.relative(opts.outDir, file)] = asset;
+						});
+					}
+					callback();
+				})
+				.catch((e) => {
+					// callback must be called outside the 'catch' callback
+					// since the 'callback' may throw the error 'e' and
+					// the Promise will catch it
+					setImmediate(() => {
+						callback(e);
+					});
+				});
+		});
+	}
+
+	private messageWriter(text: string) {
+		if (console.log) {
+			console.log(text);
+		}
+	}
+}

--- a/src/main/plugin/PluginOptions.ts
+++ b/src/main/plugin/PluginOptions.ts
@@ -1,0 +1,16 @@
+import Options from '../types/Options';
+
+export type OptionsWithAllOptionals = {
+	[P in keyof Options]?: Options[P] | undefined;
+};
+export type OptionsRequiredForPluginOptions = {
+};
+export type OptionsBase = OptionsWithAllOptionals & OptionsRequiredForPluginOptions;
+
+export default interface PluginOptions extends OptionsBase {
+	/**
+	 * true if using source files in the project file instead of emitting declaration files.
+	 * (even if useProjectSources is true, other emitting declaration files will be removed)
+	 */
+	useProjectSources?: boolean;
+}

--- a/src/main/types/Options.ts
+++ b/src/main/types/Options.ts
@@ -13,22 +13,22 @@ export default interface Options {
 	 * The export entity name in the entry module name (e.g. 'default').
 	 * If empty, module itself will be used (such as 'export = require(entry)').
 	 */
-	export: string | undefined;
+	export?: string | undefined;
 	/**
 	 * The project file (tsconfig.json) or directory (containing tsconfig.json).
 	 * If empty, './tsconfig.json' will be used.
 	 */
-	project: string | undefined;
+	project?: string | undefined;
 	/**
 	 * The root variable name to expose or empty if no declaration is needed.
 	 * If rootName contains '.', then the parent namespace also be declared.
 	 */
-	rootName: string | undefined;
+	rootName?: string | undefined;
 	/**
 	 * The output directory name.
 	 * If empty, './' will be used.
 	 */
-	outDir: string | undefined;
+	outDir?: string | undefined;
 	/**
 	 * The declaration style.
 	 *  - 'module': using 'declare module "XXX"' for all child modules.
@@ -37,18 +37,18 @@ export default interface Options {
 	 *        This style emits one file named '<moduleName>.d.ts'.
 	 * If empty, 'module' will be used.
 	 */
-	style: 'module' | 'namespace' | undefined;
+	style?: 'module' | 'namespace' | undefined;
 	/**
 	 * The 'default' name for namespace-style.
 	 * Default is '_default'.
 	 */
-	defaultName: string | undefined;
+	defaultName?: string | undefined;
 	/**
 	 * The identifier for binding modules with 'import'.
 	 * For namespace-style, this is used for the prefix of identifier. (e.g. '__module1')
 	 * Default is '__module'.
 	 */
-	importBindingName: string | undefined;
+	importBindingName?: string | undefined;
 	/**
 	 * The compiler options for TypeScript.
 	 * The project settings will be overrided by this options except for 'declaration'.
@@ -56,5 +56,5 @@ export default interface Options {
 	 */
 	compilerOptions?: ts.CompilerOptions;
 
-	list: boolean | undefined;
+	list?: boolean | undefined;
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "baseUrl": "./src/main",
     "declaration": true,
-    "lib": [ "es5", "es2015.core" ],
+    "lib": [ "es5", "es2015.core", "es2015.promise" ],
     "module": "commonjs",
     "moduleResolution": "node",
     "noImplicitReturns": true,

--- a/yarn.lock
+++ b/yarn.lock
@@ -8,6 +8,10 @@
   dependencies:
     commander "*"
 
+"@types/node@*":
+  version "9.4.0"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-9.4.0.tgz#b85a0bcf1e1cc84eb4901b7e96966aedc6f078d1"
+
 "@types/node@6":
   version "6.0.96"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-6.0.96.tgz#7bf0bf40d6ce51e93762cc47d010c8cc5ebb2179"
@@ -15,6 +19,24 @@
 "@types/semver@^5.4.0":
   version "5.5.0"
   resolved "https://registry.yarnpkg.com/@types/semver/-/semver-5.5.0.tgz#146c2a29ee7d3bae4bf2fcb274636e264c813c45"
+
+"@types/tapable@*":
+  version "0.2.4"
+  resolved "https://registry.yarnpkg.com/@types/tapable/-/tapable-0.2.4.tgz#8181a228da46185439300e600c5ae3b3b3982585"
+
+"@types/uglify-js@*":
+  version "2.6.30"
+  resolved "https://registry.yarnpkg.com/@types/uglify-js/-/uglify-js-2.6.30.tgz#257d2b6dd86673d60da476680fba90f2e30c6eef"
+  dependencies:
+    source-map "^0.6.1"
+
+"@types/webpack@2":
+  version "2.2.16"
+  resolved "https://registry.yarnpkg.com/@types/webpack/-/webpack-2.2.16.tgz#9ca93f468ab3a8eb4b6f45f589acf58c8133aa9b"
+  dependencies:
+    "@types/node" "*"
+    "@types/tapable" "*"
+    "@types/uglify-js" "*"
 
 "@types/yargs@^10.0.1":
   version "10.0.1"
@@ -232,6 +254,10 @@ sigmund@^1.0.1:
 signal-exit@^3.0.0:
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/signal-exit/-/signal-exit-3.0.2.tgz#b5fdc08f1287ea1178628e415e25132b73646c6d"
+
+source-map@^0.6.1:
+  version "0.6.1"
+  resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.6.1.tgz#74722af32e9614e9c287a8d0bbde48b5e2f1a263"
 
 string-width@^1.0.1:
   version "1.0.2"


### PR DESCRIPTION
Supports dts-pack as a webpack plugin. Example for usage:

```js
var DtsPackPlugin = require('dts-pack').DtsPackPlugin;

...
// in the configuration
{
  ...
  plugins: [
    new DtsPackPlugin({
      entry: 'index.ts',
      moduleName: 'myModule'
    })
  ]
}
```