### PR TITLE
add 'stripUnusedExports' option and feature

### DIFF
--- a/src/main/cli.ts
+++ b/src/main/cli.ts
@@ -88,6 +88,10 @@ function main(): number {
 				default: '__module',
 				description: 'The identifier for binding modules with \'import\''
 			})
+			.option('stripUnusedExports', {
+				type: 'boolean',
+				description: 'The flag whether exported entities are stripped when not used'
+			})
 			.option('list', {
 				type: 'boolean',
 				description: 'If specified, outputs all imports and exports and exit without emitting files.'
@@ -113,10 +117,7 @@ function main(): number {
 				if (!(argv.list || argv.entry || argv.moduleName)) {
 					throw '--entry and --moduleName are missing';
 				}
-				if (argv.list && (argv.entry || argv.moduleName)) {
-					throw '--list cannot be used with --entry and --moduleName';
-				}
-				if (!!argv.entry !== !!argv.moduleName) {
+				if (!argv.list && !!argv.entry !== !!argv.moduleName) {
 					throw 'both --entry and --moduleName must be specified';
 				}
 				if (argv.defaultName === 'default') {

--- a/src/main/core/collectUnusedSymbols.ts
+++ b/src/main/core/collectUnusedSymbols.ts
@@ -1,0 +1,193 @@
+import * as ts from 'typescript';
+
+import ExportData from '../types/ExportData';
+
+import mapEntityWithName from './mapEntityWithName';
+
+function isDeclarationSymbol(symbol: ts.Symbol, node: ts.Node) {
+	const parent = node.parent;
+	if (symbol.flags === ts.SymbolFlags.Alias) {
+		return false;
+	}
+	return !!symbol.declarations && symbol.declarations.some((d) => d === parent);
+}
+
+function isSymbolReferring(symTarget: ts.Symbol, symReference: ts.Symbol, nodeReference: ts.Node, outExportedSymbols: ts.Symbol[]): boolean {
+	if (symReference.flags === ts.SymbolFlags.Alias) {
+		if (!symReference.declarations) {
+			return false;
+		}
+		// 'export { A as B };'
+		return symReference.declarations.some((d) => {
+			if (ts.isExportSpecifier(d)) {
+				const i = d.propertyName || d.name;
+				if (i.text === symTarget.name) {
+					outExportedSymbols.push(symTarget);
+					return true;
+				}
+				return false;
+			} else {
+				return !!symTarget.declarations && symTarget.declarations.some((x) => x === d);
+			}
+		});
+	} else if (!symTarget.declarations || symTarget.name === symReference.name) {
+		return false;
+	} else {
+		let node: ts.Node | undefined = nodeReference;
+		while (node) {
+			if (symTarget.declarations.some((d) => d === node)) {
+				return true;
+			}
+			node = node.parent;
+		}
+		return false;
+	}
+}
+
+function reduceNoEntryMap<T>(map: Map<T, T[]>, keys: T[], equator: (a: T, b: T) => boolean, reduceable?: (x: T) => boolean): T[] {
+	const reduced: T[] = [];
+	while (true) {
+		let needMoreReduction = false;
+		for (let i = keys.length - 1; i >= 0; --i) {
+			const t = keys[i];
+			const arr = map.get(t)!;
+			if (!arr.length && (!reduceable || reduceable(t))) {
+				keys.splice(i, 1);
+				map.delete(t);
+				reduced.push(t);
+				keys.forEach((x) => {
+					const arr2 = map.get(x)!;
+					for (let j = arr2.length - 1; j >= 0; --j) {
+						if (equator(arr2[j], t)) {
+							arr2.splice(j, 1);
+						}
+					}
+				});
+				needMoreReduction = true;
+			}
+		}
+		if (!needMoreReduction) {
+			break;
+		}
+	}
+	return reduced;
+}
+
+function findParentSymbol(symbols: ts.Symbol[], childNode: ts.Node): ts.Symbol | undefined {
+	for (let i = symbols.length - 1; i >= 0; --i) {
+		const x = symbols[i];
+		let p: ts.Node | undefined = childNode;
+		while (p) {
+			if (x.declarations && x.declarations.some((d) => d === p)) {
+				return x;
+			}
+			p = p.parent;
+		}
+	}
+	return undefined;
+}
+
+function isUsingExportSymbol(source: ts.SourceFile, sym: ts.Symbol, unusedExports: ExportData[] | undefined): boolean {
+	if (!unusedExports) {
+		return true;
+	}
+	let symName = sym.name;
+	// sym.name may be 'default', so get original entity name
+	if (sym.declarations) {
+		sym.declarations.forEach((d) => {
+			mapEntityWithName((_n, exportName, baseName, i) => {
+				if (i === 0) {
+					symName = baseName || exportName;
+				}
+			}, d, source);
+		});
+	}
+	return !unusedExports.some((exp) => {
+		return exp.namedExports.some((x) => {
+			return (x.baseName || x.name) === symName;
+		});
+	});
+}
+
+export default function collectUnusedSymbols(sourceFile: ts.SourceFile, typeChecker: ts.TypeChecker, unusedExports?: ExportData[]): string[] {
+	const symbols = new Map<ts.Symbol, ts.Symbol[]>();
+	const symKeys: ts.Symbol[] = [];
+	const exportedSymKeys: ts.Symbol[] = [];
+
+	function processNode(node: ts.Node) {
+		const baseSym = typeChecker.getSymbolAtLocation(node);
+		if (baseSym) {
+			//const s = typeChecker.getAliasedSymbol(baseSym);
+			const s = baseSym;
+			if (isDeclarationSymbol(s, node)) {
+				let parentSymbol: ts.Symbol | undefined;
+				if (s.getFlags() === ts.SymbolFlags.Method ||
+					s.getFlags() === ts.SymbolFlags.Property ||
+					s.getFlags() === ts.SymbolFlags.NamespaceModule) {
+					parentSymbol = findParentSymbol(symKeys, node);
+				}
+				if (!symbols.get(s)) {
+					//console.log('Declaration symbol:', s.name);
+					symbols.set(s, []);
+					symKeys.push(s);
+				}
+				if (parentSymbol) {
+					//console.log(`  (found parent symbol: ${parentSymbol.name})`);
+					// 'parent (parentSymbol) is referring child (s)'
+					const arr = symbols.get(s)!;
+					arr.push(parentSymbol);
+				}
+			} else {
+				//console.log('Reference symbol:', s.name);
+				symKeys.forEach((x) => {
+					if (isSymbolReferring(x, s, node, exportedSymKeys)) {
+						//console.log(`  (found declaration: ${x.name})`);
+						// 'x' is referring 's'
+						const arr = symbols.get(s);
+						if (arr) {
+							arr.push(x);
+						}
+					}
+				});
+			}
+		}
+		node.forEachChild(processNode);
+	}
+	sourceFile.forEachChild(processNode);
+
+	//console.log(`collectUnusedSymbols [file = ${sourceFile.fileName}]`);
+	//console.log(`  unused exports:`);
+	//unusedExports && unusedExports.forEach((exp) => exp.namedExports.forEach((x) => console.log(`    ${x.baseName || x.name} as ${x.name}`)));
+	return reduceNoEntryMap(symbols, symKeys, (a, b) => a.name === b.name, (s) => {
+		const usingExport = isUsingExportSymbol(sourceFile, s, unusedExports);
+		if (!s.declarations) {
+			return true;
+		}
+		//console.log(`  Symbol '${s.name}'[${s.flags}]: usingExport = `, usingExport);
+		if (usingExport && exportedSymKeys.some((x) => x === s)) {
+			return false;
+		}
+		const d = s.declarations[0];
+		if (!d) {
+			return true;
+		}
+		return !usingExport || !(
+			ts.isExportDeclaration(d) ||
+			ts.isExportAssignment(d) ||
+			ts.isExportSpecifier(d) ||
+			(d.modifiers && d.modifiers.some((m) => m.kind === ts.SyntaxKind.ExportKeyword))
+		);
+	}).map((sym) => {
+		let name = sym.name;
+		if (sym.declarations) {
+			sym.declarations.forEach((d) => {
+				mapEntityWithName((_n, exportName, baseName, i) => {
+					if (i === 0) {
+						name = baseName || exportName;
+					}
+				}, d, sourceFile);
+			});
+		}
+		return name;
+	});
+}

--- a/src/main/core/createProgramFromMemory.ts
+++ b/src/main/core/createProgramFromMemory.ts
@@ -1,0 +1,67 @@
+import * as ts from 'typescript';
+import * as path from 'path';
+
+class CompilerHostForMemoryFiles implements ts.CompilerHost {
+	writeFile: ts.WriteFileCallback;
+	private files: { [fileName: string]: string };
+	private baseHost: ts.CompilerHost;
+
+	constructor(files: { [fileName: string]: string }, baseHost: ts.CompilerHost) {
+		this.files = files;
+		this.baseHost = baseHost;
+		this.writeFile = baseHost.writeFile;
+	}
+
+	getSourceFile(fileName: string, languageVersion: ts.ScriptTarget, onError?: ((message: string) => void) | undefined, shouldCreateNewSourceFile?: boolean | undefined): ts.SourceFile | undefined {
+		const f = path.resolve(fileName);
+		const source = this.files[f];
+		if (typeof (source) === 'string') {
+			return ts.createSourceFile(fileName, source, languageVersion);
+		}
+		return this.baseHost.getSourceFile(fileName, languageVersion, onError, shouldCreateNewSourceFile);
+	}
+	getDefaultLibFileName(options: ts.CompilerOptions): string {
+		return this.baseHost.getDefaultLibFileName(options);
+	}
+	getCurrentDirectory(): string {
+		return this.baseHost.getCurrentDirectory();
+	}
+	getDirectories(path: string): string[] {
+		return this.baseHost.getDirectories(path);
+	}
+	getCanonicalFileName(fileName: string): string {
+		return this.baseHost.getCanonicalFileName(fileName);
+	}
+	useCaseSensitiveFileNames(): boolean {
+		return this.baseHost.useCaseSensitiveFileNames();
+	}
+	getNewLine(): string {
+		return this.baseHost.getNewLine();
+	}
+	fileExists(fileName: string): boolean {
+		const f = path.resolve(fileName);
+		const source = this.files[f];
+		if (typeof (source) === 'string') {
+			return true;
+		}
+		return this.baseHost.fileExists(fileName);
+	}
+	readFile(fileName: string): string | undefined {
+		const f = path.resolve(fileName);
+		const source = this.files[f];
+		if (typeof (source) === 'string') {
+			return source;
+		}
+		return this.baseHost.readFile(fileName);
+	}
+}
+
+export default function createProgramFromMemory(
+	files: { [fileName: string]: string },
+	compilerOptions: ts.CompilerOptions,
+	host: ts.CompilerHost,
+	oldProgram?: ts.Program
+): ts.Program {
+	const newHost = new CompilerHostForMemoryFiles(files, host);
+	return ts.createProgram(Object.keys(files), compilerOptions, newHost, oldProgram);
+}

--- a/src/main/core/getNodeWithStrippedExports.ts
+++ b/src/main/core/getNodeWithStrippedExports.ts
@@ -1,0 +1,57 @@
+import * as ts from 'typescript';
+
+import ExportDataMap from '../types/ExportDataMap';
+
+import mapEntityWithName from './mapEntityWithName';
+
+export default function getNodeWithStrippedExports<TNode extends ts.Node>(
+	sourceFile: ts.SourceFile,
+	resolvedFileName: string,
+	node: TNode,
+	stripUnusedExports: ExportDataMap
+): TNode | null {
+	const a = stripUnusedExports[resolvedFileName];
+	if (!a || !a.length) {
+		return node;
+	}
+	if (ts.isExportDeclaration(node)) {
+		if (node.exportClause) {
+			const newElem = node.exportClause.elements.filter((element) => {
+				return !a.some((exp) => {
+					return exp.namedExports.some((x) => element.name.text === (x.baseName || x.name));
+				});
+			});
+			if (!newElem.length) {
+				return null;
+			}
+			if (newElem.length < node.exportClause.elements.length) {
+				node.exportClause.elements = ts.createNodeArray(newElem);
+			}
+		}
+	} else if (ts.isExportAssignment(node) && !node.isExportEquals) {
+		if (a.some((exp) => exp.namedExports.some((x) => 'default' === x.name))) {
+			return null;
+		}
+	} else if (node.modifiers && node.modifiers.some((m) => m.kind === ts.SyntaxKind.ExportKeyword)) {
+		if (ts.isVariableStatement(node)) {
+			const decls = node.declarationList.declarations.filter(
+				(decl) => !a.some((exp) => exp.namedExports.some((x) => decl.name.getText(sourceFile) === (x.baseName || x.name)))
+			);
+			if (decls.length === 0) {
+				return null;
+			} else if (decls.length < node.declarationList.declarations.length) {
+				node.declarationList.declarations = ts.createNodeArray(decls);
+			}
+		} else {
+			const names = mapEntityWithName((_n, _e, baseName) => {
+				return baseName || null;
+			}, node, sourceFile);
+			if (names[0] !== null) {
+				if (a.some((exp) => exp.namedExports.some((x) => names[0] === (x.baseName || x.name)))) {
+					return null;
+				}
+			}
+		}
+	}
+	return node;
+}

--- a/src/main/core/mapEntityWithName.ts
+++ b/src/main/core/mapEntityWithName.ts
@@ -1,0 +1,24 @@
+import * as ts from 'typescript';
+
+export default function mapEntityWithName<T>(
+	mapCallback: (node: ts.Node, exportName: string, baseName: string | undefined, index: number) => T,
+	node: ts.Node,
+	source?: ts.SourceFile
+): T[] {
+	const isDefault = node.modifiers && node.modifiers.some((m) => m.kind === ts.SyntaxKind.DefaultKeyword);
+	if (ts.isVariableStatement(node)) {
+		return node.declarationList.declarations.map((d, i) => mapCallback(d, d.name.getText(source), undefined, i));
+	} else if (ts.isFunctionDeclaration(node) ||
+		ts.isClassDeclaration(node) ||
+		ts.isInterfaceDeclaration(node) ||
+		ts.isTypeAliasDeclaration(node) ||
+		ts.isEnumDeclaration(node) ||
+		ts.isModuleDeclaration(node)) {
+		const baseName = node.name && node.name.text;
+		return [mapCallback(node, (isDefault || !node.name) ? 'default' : baseName!, baseName, 0)];
+	} else if (ts.isImportEqualsDeclaration(node)) {
+		return [mapCallback(node, node.name.text, undefined, 0)];
+	} else {
+		return [];
+	}
+}

--- a/src/main/core/pickupUnusedExports.ts
+++ b/src/main/core/pickupUnusedExports.ts
@@ -1,0 +1,157 @@
+import * as ts from 'typescript';
+import * as path from 'path';
+
+import ExportData from '../types/ExportData';
+import ExportDataMap from '../types/ExportDataMap';
+import ImportsAndExports from '../types/ImportsAndExports';
+import resolveModule from '../packer/resolveModule';
+import isEqualPath from '../utils/isEqualPath';
+
+function cloneExportData(data: ExportData[]): ExportData[] {
+	return data.map((x) => {
+		return {
+			baseName: x.baseName,
+			moduleName: x.moduleName,
+			node: x.node,
+			namedExports: x.namedExports.map((named) => {
+				return {
+					name: named.name,
+					baseName: named.baseName,
+					node: named.node
+				} as typeof named;
+			})
+		} as ExportData;
+	});
+}
+
+export default function pickupUnusedExports(
+	entryFile: string,
+	entryExport: string | undefined,
+	allData: { [fileName: string]: ImportsAndExports },
+	host: ts.CompilerHost,
+	compilerOptions: ts.CompilerOptions,
+	resolutionCache: ts.ModuleResolutionCache
+): ExportDataMap {
+	const ret: ExportDataMap = {};
+	Object.keys(allData).forEach((fileName) => {
+		if (isEqualPath(entryFile, fileName)) {
+			entryFile = fileName;
+		}
+		ret[fileName] = cloneExportData(allData[fileName]!.exports);
+	});
+
+	const usedDataFileNames: string[] = [];
+	const usedDataExports: ExportDataMap = {};
+
+	const processUsingData = (targetFileName: string, fromName: string | undefined): boolean => {
+		const d = ret[targetFileName];
+		if (!d) {
+			return false;
+		}
+		if (typeof (fromName) === 'undefined' || fromName === '*') {
+			// all exports are 'used'
+			usedDataFileNames.push(targetFileName);
+			usedDataExports[targetFileName] = d;
+			ret[targetFileName] = [];
+			return true;
+		} else {
+			for (let i = d.length - 1; i >= 0; --i) {
+				const x = d[i];
+				let usedExports: typeof x.namedExports = [];
+				for (let j = x.namedExports.length - 1; j >= 0; --j) {
+					const named = x.namedExports[j];
+					if (named.name === fromName) {
+						usedExports = usedExports.concat(x.namedExports.splice(j, 1));
+						//break;
+					}
+				}
+				if (usedExports.length > 0) {
+					const base = usedDataExports[targetFileName];
+					if (!x.namedExports.length) {
+						const a = d.splice(i, 1);
+						a[0].namedExports = usedExports;
+						if (base) {
+							usedDataExports[targetFileName] = base.concat(a);
+						} else {
+							usedDataFileNames.push(targetFileName);
+							usedDataExports[targetFileName] = a
+						}
+					} else {
+						const newData = {
+							moduleName: x.moduleName,
+							baseName: x.baseName,
+							node: x.node,
+							namedExports: usedExports
+						};
+						if (base) {
+							usedDataExports[targetFileName] = base.concat(newData);
+						} else {
+							usedDataFileNames.push(targetFileName);
+							usedDataExports[targetFileName] = [newData];
+						}
+					}
+					return true;
+				}
+			}
+			return false;
+		}
+	};
+
+	if (!processUsingData(entryFile, entryExport)) {
+		return {};
+	}
+
+	let lastUsedDataKeyIndex = 0;
+	while (true) {
+		let changed = false;
+		let i = lastUsedDataKeyIndex;
+		lastUsedDataKeyIndex = usedDataFileNames.length;
+		for (; i < usedDataFileNames.length; ++i) {
+			const fileName = usedDataFileNames[i];
+			//console.log(`* pickupUnusedExports [current = ${fileName}]`);
+			// walk all imports in the file marked 'used'
+			// and pick up using modules/exports
+			const data = allData[fileName];
+			data.imports.forEach((imp) => {
+				if (imp.name) {
+					//console.log(`  * import: name: ${imp.name}, module: ${imp.module}, fromName: ${imp.fromName}`);
+					const importModule = resolveModule(host, compilerOptions, resolutionCache, imp.module, fileName.replace(/\\/g, '/'));
+					if (importModule) {
+						const importFileName = path.resolve(importModule.resolvedFileName);
+						//console.log(`  * import file: ${importFileName}`);
+						if (allData[importFileName]) {
+							if (processUsingData(importFileName, imp.fromName)) {
+								changed = true;
+							}
+						}
+					}
+				}
+			});
+			data.exports.forEach((exp) => {
+				if (exp.moduleName) {
+					//console.log(`  * export-from: module: ${exp.moduleName}`);
+					const importModule = resolveModule(host, compilerOptions, resolutionCache, exp.moduleName, fileName.replace(/\\/g, '/'));
+					if (importModule) {
+						const importFileName = path.resolve(importModule.resolvedFileName);
+						//console.log(`  * import file: ${importFileName}`);
+						if (allData[importFileName]) {
+							if (processUsingData(importFileName, void (0))) {
+								changed = true;
+							}
+						}
+					}
+				}
+			});
+		}
+		if (!changed) {
+			break;
+		}
+	}
+	Object.keys(ret).forEach((s) => {
+		const a = ret[s]!;
+		if (a.length === 0) {
+			delete ret[s];
+		}
+	});
+	return ret;
+}

--- a/src/main/types/ExportDataMap.ts
+++ b/src/main/types/ExportDataMap.ts
@@ -1,0 +1,6 @@
+
+import ExportData from './ExportData';
+
+export default interface ExportDataMap {
+	[fileName: string]: ExportData[];
+}

--- a/src/main/types/Options.ts
+++ b/src/main/types/Options.ts
@@ -56,5 +56,11 @@ export default interface Options {
 	 */
 	compilerOptions?: ts.CompilerOptions;
 
+	/**
+	 * The boolean value whether exported entities are stripped when not used.
+	 */
+	stripUnusedExports?: boolean | undefined;
+
+	// (for command-line option)
 	list?: boolean | undefined;
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "baseUrl": "./src/main",
     "declaration": true,
-    "lib": [ "es5", "es2015.core", "es2015.promise" ],
+    "lib": [ "es5", "es2015.core", "es2015.promise", "es2015.collection" ],
     "module": "commonjs",
     "moduleResolution": "node",
     "noImplicitReturns": true,


### PR DESCRIPTION
example:

* file.ts

```ts
const Value1 = 'text';
export { Value1 };
export function myFunc1() { }
export default function myDefaultFunc() { }
```

* index.ts

```ts
import { myFunc1 } from './file1';
export { myFunc1 };
```

with `dts-pack -e index.ts -m myModule --stripUnusedExports`, myModule.d.ts will be:

```ts
declare module 'myModule/file1' {
    const Value1 = "text";
    export function myFunc1(): void;
}

declare module 'myModule/index' {
    import { myFunc1 } from 'myModule/file1';
    export { myFunc1 };
}
```

Unused `Value1` and `myDefaultFunc` are stripped from 'myModule/file1'.
(Note that the local constant value `Value1` is not stripped; it may needs to be improved in the future.)