### PR TITLE
Support newer typescript versions

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
   },
   "dependencies": {
     "editorconfig": "^0.15.0",
-    "typescript": "^2.6.2",
+    "typescript": ">=2.6.2",
     "yargs": "^11.0.0"
   },
   "devDependencies": {


### PR DESCRIPTION
Fixes #9.

I confirmed that dts-pack should work with TS 3.9 (and `typescript@4.0.0-dev.20200523`), so this PR will change the dependency version of typescript.